### PR TITLE
Avg returns NaN when 1 or more ping attempts fail - added a fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ Returned data is an object which looks like this:
   avg: 19.7848844,
   max: 35.306233,
   min: 16.526067,
+  dropped: 0,
+  success_avg: 19.7848844,
   results:
    [
     { seq: 0, time: 35.306233 },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tcp-ping",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "A ping utility using TCP connection",
   "main": "ping.js",
   "scripts": {

--- a/ping.js
+++ b/ping.js
@@ -42,7 +42,15 @@ var ping = function(options, callback) {
             var min = results.reduce(function(prev, curr) {
                 return (prev < curr.time) ? prev : curr.time;
             }, results[0].time);
+            var dropped = results.reduce(function(prev, curr) {
+                return (curr.err) ? prev + 1 : prev;
+            }, 0);
+            var success_avg = results.reduce(function(prev, curr) {
+                if (curr.err) return prev;
+                return prev + curr.time;
+            }, 0);
             avg = avg / results.length;
+            success_avg = success_avg / (results.length - dropped);
             var out = {
                 address: options.address,
                 port: options.port,
@@ -50,6 +58,8 @@ var ping = function(options, callback) {
                 avg: avg,
                 max: max,
                 min: min,
+                dropped: dropped,
+                success_avg: success_avg,
                 results: results
             };
             callback(undefined, out);


### PR DESCRIPTION
When 1 or more ping attempts fail, `avg` in the return object will be `NaN`, though `min` and `max` are returned correctly. As a backwards compatible way of addressing this, I've added two more properties in the return object:

```
{
    ...
    dropped: 1,
    success_avg: 23.6245
}
```

`dropped` will show how many of the attempts errored out. `success_avg` will return the average of all successful pings, ignoring the errors. If all pings are successful, `success_avg` and `avg` will be equal.

Since this is an old project that gets quite a bit of use, I decided to add new properties instead of changing the existing one to avoid breaking changes. It could easily be changed to fix the existing functionality, though.

The version number was updated to `0.1.2` and `README.md` was updated to show the two new properties in the sample return object.